### PR TITLE
CORE-205 Clear sync event deque before starting sync protocol

### DIFF
--- a/src/Adapter.hxx
+++ b/src/Adapter.hxx
@@ -44,6 +44,7 @@ namespace pEp {
             // 3. Enter Sync Event Processing Loop (do_sync_protocol())
             // this internally calls _retrieve_next_sync_event
             pEpLog("sync protocol loop started");
+            sync_evt_q.clear();
             ::do_sync_protocol(session());
             pEpLog("sync protocol loop ended");
 


### PR DESCRIPTION
This is done to cooperate with the apps.
After user leaves device group one possible workaround to be able to sync again is stopping sync, which adds a null event to the deque. Then when user tries to start sync again we don't want to find that null event which will cause sync to stop again.